### PR TITLE
Make recovery path configurable.

### DIFF
--- a/spark-env.sh
+++ b/spark-env.sh
@@ -1,5 +1,8 @@
 SPARK_NO_DAEMONIZE=true
 
-if [ -n "$ZOOKEEPER_URL" ]; then 
-	export SPARK_DAEMON_JAVA_OPTS="-Dspark.deploy.recoveryMode=ZOOKEEPER -Dspark.deploy.zookeeper.dir=/spark -Dspark.deploy.zookeeper.url=$ZOOKEEPER_URL"
+if [ -n "$ZOOKEEPER_URL" ] && [ "$ZOOKEEPER_PATH" ]; then 
+	export SPARK_DAEMON_JAVA_OPTS="-Dspark.deploy.recoveryMode=ZOOKEEPER -Dspark.deploy.zookeeper.dir=$ZOOKEEPER_PATH -Dspark.deploy.zookeeper.url=$ZOOKEEPER_URL"
+elif [ -n "$ZOOKEEPER_URL" ] || [ "$ZOOKEEPER_PATH" ]; then
+	echo "Both ZOOKEEPER_URL and ZOOKEEPER_PATH should be set."
+	exit 1
 fi


### PR DESCRIPTION
All spark cluster created with this docker image that used Zookeeper for master recovery will use the same Zookeeper path `/spark`. This PR forces the user to choose a path if they want to use Zookeeper recovery.