### PR TITLE
Rolling back to Spark 2.1.0

### DIFF
--- a/Dockerfile-2.1.x
+++ b/Dockerfile-2.1.x
@@ -7,7 +7,7 @@ RUN apk add --no-cache bash coreutils procps python wget \
 ENV AMAZON_SDK_VERSION=1.7.4
 ENV HADOOP_AWS_VERSION=2.7.3
 ENV HADOOP_VERSION=2.7
-ENV SPARK_VERSION=2.1.1
+ENV SPARK_VERSION=2.1.0
 
 RUN wget http://d3kbcqa49mib13.cloudfront.net/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz -P /tmp \
  && wget http://central.maven.org/maven2/com/amazonaws/aws-java-sdk/${AMAZON_SDK_VERSION}/aws-java-sdk-${AMAZON_SDK_VERSION}.jar -P /tmp \ 


### PR DESCRIPTION
Rolling back to Spark 2.1.0 to allow compatibility with `sofianito/zeppelin:0.7.1`.