### PR TITLE
Using python3

### DIFF
--- a/Dockerfile-2.1.0
+++ b/Dockerfile-2.1.0
@@ -1,7 +1,9 @@
 FROM openjdk:8u121-jre-alpine
 MAINTAINER Luis Angel Vicente Sanchez "luis@bigcente.ch"
 
-RUN apk add --no-cache bash coreutils procps python wget \
+RUN apk add --no-cache bash coreutils procps python3 wget \
+ && cd /usr/bin \
+ && ln -s python3.5 python \
  && rm -rf /var/cache/apk/*
 
 ENV AMAZON_SDK_VERSION=1.7.4


### PR DESCRIPTION
Trying to run pyspark notebook from Zeppelin 0.7.1 fails because python3 is missing.